### PR TITLE
support cyrillic lock name

### DIFF
--- a/distributedflock/Zookeeper.py
+++ b/distributedflock/Zookeeper.py
@@ -22,7 +22,7 @@
 import logging
 import socket
 import uuid
-import os
+import sys
 
 from ZKeeperAPI import zkapi
 

--- a/distributedflock/Zookeeper.py
+++ b/distributedflock/Zookeeper.py
@@ -22,9 +22,11 @@
 import logging
 import socket
 import uuid
+import os
 
 from ZKeeperAPI import zkapi
 
+PY27 = sys.version_info >= (2,7)
 
 class ZKLockServer(object):
     def __init__(self, **config):
@@ -43,7 +45,10 @@ class ZKLockServer(object):
                     raise Exception(msg)
 
             self.lock = config['name']
-            self.lockpath = '/{}/{}'.format(self.id, self.lock)
+            if PY27:
+                self.lockpath = '/{}/{}'.format(self.id, self.lock)
+            else:
+                self.lockpath = '/%s/%s' % (self.id, self.lock)
             self.locked = False
             self.lock_content = socket.gethostname() + str(uuid.uuid4())
         except Exception as err:
@@ -65,7 +70,10 @@ class ZKLockServer(object):
 
     def set_lock_name(self, name):
         self.lock = name
-        self.lockpath = '/{}/{}'.format(self.id, self.lock)
+        if PY27:
+            self.lockpath = '/{}/{}'.format(self.id, self.lock)
+        else:
+            self.lockpath = '/%s/%s' % (self.id, self.lock)
 
     def releaselock(self):
         try:

--- a/distributedflock/Zookeeper.py
+++ b/distributedflock/Zookeeper.py
@@ -43,7 +43,7 @@ class ZKLockServer(object):
                     raise Exception(msg)
 
             self.lock = config['name']
-            self.lockpath = '/%s/%s' % (self.id, self.lock)
+            self.lockpath = '/{}/{}'.format(self.id, self.lock)
             self.locked = False
             self.lock_content = socket.gethostname() + str(uuid.uuid4())
         except Exception as err:
@@ -65,7 +65,7 @@ class ZKLockServer(object):
 
     def set_lock_name(self, name):
         self.lock = name
-        self.lockpath = '/%s/%s' % (self.id, self.lock)
+        self.lockpath = '/{}/{}'.format(self.id, self.lock)
 
     def releaselock(self):
         try:


### PR DESCRIPTION
We want to use cyrillic name for lock, for example:
`zk-flock приветики 'sleep 300' -c <path_to_conf> -x 111`

format better works with strings in this case, interpolation need extra encode/decode to/from utf-8

Tested only for cmd command i wrote upper
