### PR TITLE
rebuild with data.tar.gz instead of data.tar.xz - compatibility for o…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+zk-flock (0.1.4.4) unstable; urgency=medium
+
+  * Rebuild with tar.gz instead of tar.xz
+
+ -- Arsenev Alexey <aarseniev@yandex-team.ru>  Wed, 09 Nov 2016 10:32:05 +0300
+
 zk-flock (0.1.4.3) unstable; urgency=medium
 
   * Fix work with cyrillic lock name (>= python2.7). Python 2.6 work logic not changed

--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,8 @@ ifeq (lucid,$(shell lsb_release -sc))
 	    PYTHON_HELPER=python2
 	endif
 
+override_dh_builddeb:
+	dh_builddeb -- -Zgzip
 
 %:
 		dh $@ --with=$(PYTHON_HELPER)


### PR DESCRIPTION
build package with data.tar.gz instead of data.tar.xz
Older versions of dpkg dont know what to do with xz format