### PR TITLE
fix usage of minlocktime parameter

### DIFF
--- a/zk-flock
+++ b/zk-flock
@@ -201,7 +201,7 @@ def main(cmd_arg, zk_cfg, period=None, exitcode=0, sequence=0, pdeathsig_num=0, 
 
     cv = Condition()
 
-    def sigterm_and_sigchld_handle(p, signum, frame, minlocktime=5):
+    def sigterm_and_sigchld_handle(p, signum, frame):
         time.sleep(minlocktime)
         # TBD - split by two handlers for each signal
         if signum == signal.SIGTERM:


### PR DESCRIPTION
before this fix script was always sleepeing at least 5 sec because of default value overriding real value from arguments

now parameters works 
```
(python-flock) semin-serg@semin-serg-ub:~/other-projects/python-flock$ time ./zk-flock --minlocktime=30 test_lock date
Вт июн  2 23:06:27 MSK 2020

real    0m30,729s
user    0m0,501s
sys     0m0,200s
(python-flock) semin-serg@semin-serg-ub:~/other-projects/python-flock$ time ./zk-flock test_lock date
Вт июн  2 23:07:06 MSK 2020

real    0m5,731s
user    0m0,546s
sys     0m0,172s
(python-flock) semin-serg@semin-serg-ub:~/other-projects/python-flock$ time ./zk-flock --minlocktime=1 test_lock date
Вт июн  2 23:07:22 MSK 2020

real    0m1,815s
user    0m0,590s
sys     0m0,213s
```